### PR TITLE
fix: broaden submit button selector for EhSyringe compatibility

### DIFF
--- a/src/composables/useFavorite.ts
+++ b/src/composables/useFavorite.ts
@@ -10,7 +10,7 @@ export function useFavorite(favoriteInnerHtml: Ref<string>) {
 
   function setRequestEvents(target: HTMLElement, popup: Ref<HTMLElement | undefined>, isPopupShow: Ref<boolean>) {
     // set submit event
-    const submitButton = popup.value?.querySelector('input[type=submit]')
+    const submitButton = popup.value?.querySelector('[type=submit]')
     submitButton?.addEventListener('click', async event => {
       event.preventDefault()
 


### PR DESCRIPTION
resolve #76

原版
```html
<input type="submit" name="apply" value="Add to Favorites">
```

EhSyringe 版
```html
<button type="submit" name="apply" value="Add to Favorites" ehs-input=""> 添加到收藏夹</button>
```

EhSyringe 會「将 input[type=submit] 等按钮替换为 button[ehs-input]，避免 value 属性被翻译导致提交内容错误」

https://github.com/EhTagTranslation/EhSyringe/blob/926f913aaf95b6aeadaf3eef42ba72638791c82d/src/plugin/syringe/index.ts#L575-L594

解決方法是把選擇器改成 `[type=submit]`