### PR TITLE
feat(gallery): enhance torrent popup with full in-modal navigation

### DIFF
--- a/src/components/GalleryEnhancer/GalleryEnhancer.vue
+++ b/src/components/GalleryEnhancer/GalleryEnhancer.vue
@@ -66,7 +66,7 @@ const {
 } = usePositions()
 
 const { setHentaiAtHomeEvent, setDirectDownloadEvent, setCancelArchiveEvent, quickDownload } = useArchive()
-const { downloadTorrent, addMagnetCopyButtons } = useTorrent()
+const { downloadTorrent, addMagnetCopyButtons, setTorrentPopupEvents } = useTorrent(torrentInnerHtml)
 const { setRequestEvents } = useFavorite(favoriteInnerHtml)
 
 if (betterPopupSwitch.value) {
@@ -105,20 +105,25 @@ function setArchiveClickEvent() {
 
 const { setAsDownloaded } = useHighlight()
 
-function setTorrentClickEvent() {
-  setRequestEvents(archiveLinkAnchor, favoritePopup, isFavoritePopupShow)
-  const isOnlyOneTorrent = torrentLinkAnchor.innerText.endsWith('(1)')
-
+function setupTorrentPopupContent() {
   addMagnetCopyButtons(torrentPopup)
 
   const torrentDownloadLinks = getElements('a', torrentPopup.value)
   if (torrentDownloadLinks?.length) {
-    torrentDownloadLinks?.forEach(link => {
+    torrentDownloadLinks.forEach(link => {
       link.addEventListener('click', () => {
         setAsDownloaded(unsafeWindow.gid)
       })
     })
   }
+}
+
+function setTorrentClickEvent() {
+  setRequestEvents(archiveLinkAnchor, favoritePopup, isFavoritePopupShow)
+  const isOnlyOneTorrent = torrentLinkAnchor.innerText.endsWith('(1)')
+
+  setupTorrentPopupContent()
+  setTorrentPopupEvents(torrentPopup, setupTorrentPopupContent)
 
   torrentLinkAnchor.addEventListener('click', event => {
     event.preventDefault()

--- a/src/composables/useFetchPopups.ts
+++ b/src/composables/useFetchPopups.ts
@@ -50,10 +50,21 @@ export function useFetchPopups() {
     }
 
     const doc = await getDoc(link)
-    const popupContent = getPopupContent(doc, '#torrentinfo > div:first-child')
+    const popupContent = getPopupContent(doc, '#torrentinfo')
     if (!popupContent) {
       logger.error('popup content not found.')
       return ''
+    }
+
+    const listContainer = popupContent.querySelector<HTMLElement>(':scope > div:first-child')
+    if (listContainer) {
+      listContainer.style.height = 'auto'
+    }
+
+    const uploadSection = popupContent.querySelector<HTMLElement>(':scope > div:last-child')
+    if (uploadSection) {
+      uploadSection.style.margin = '0'
+      uploadSection.style.borderTop = 'none'
     }
 
     logger.log('End')

--- a/src/composables/useTorrent.ts
+++ b/src/composables/useTorrent.ts
@@ -1,9 +1,11 @@
 import type { Ref } from 'vue'
+import { nextTick } from 'vue'
 import { GM_setClipboard } from 'vite-plugin-monkey/dist/client'
 
-import { getElement } from '@/utils/commons'
+import { getElement, getDoc } from '@/utils/commons'
+import { Logger } from '@/utils/logger'
 
-export function useTorrent() {
+export function useTorrent(torrentInnerHtml: Ref<string>) {
   function downloadTorrent(popup: Ref<HTMLElement | undefined>) {
     getElement('a', popup.value)?.click()
   }
@@ -75,9 +77,165 @@ export function useTorrent() {
     })
   }
 
+  /**
+   * 攔截 torrent popup 內所有頁面的 form submit，改用 fetch 在 modal 內導航
+   */
+  function setTorrentPopupEvents(
+    popup: Ref<HTMLElement | undefined>,
+    onContentChanged: () => void,
+  ) {
+    if (!popup.value) return
+
+    const logger = new Logger('Torrent Popup Events')
+    let cachedHtml = ''
+
+    bindListFormEvents()
+
+    async function fetchAndUpdate(url: string, params: URLSearchParams) {
+      const doc = await getDoc(url, { method: 'POST', body: params })
+      const html = processInfoResponse(doc)
+      if (!html) {
+        logger.error('content not found in response.')
+        return false
+      }
+      torrentInnerHtml.value = html
+      return true
+    }
+
+    function buildParams(form: HTMLFormElement, submitter?: HTMLElement | null) {
+      const params = new URLSearchParams()
+      new FormData(form).forEach((value, key) => {
+        params.append(key, value as string)
+      })
+      if (submitter instanceof HTMLInputElement || submitter instanceof HTMLButtonElement) {
+        params.append(submitter.name, submitter.value)
+      }
+      return params
+    }
+
+    function processInfoResponse(doc: Document): string | null {
+      const content = getElement('#torrentinfo', doc)
+        || getElement('.stuffbox', doc)
+
+      if (!content) return null
+
+      content.removeAttribute('style')
+
+      const styles = doc.querySelectorAll('head style')
+      let styleHtml = ''
+      styles.forEach(style => {
+        styleHtml += style.outerHTML
+      })
+
+      return styleHtml + content.innerHTML
+    }
+
+    function bindListFormEvents() {
+      if (!popup.value) return
+
+      const forms = popup.value.querySelectorAll('form')
+      forms.forEach(form => {
+        // 上傳表單跨域，不攔截，改在新分頁開啟
+        if (form.enctype === 'multipart/form-data') {
+          form.target = '_blank'
+          return
+        }
+
+        form.addEventListener('submit', async event => {
+          event.preventDefault()
+          const submitter = (event as SubmitEvent).submitter
+          if (!submitter) return
+
+          const url = form.getAttribute('action')
+          if (!url) {
+            logger.error('form action not found.')
+            return
+          }
+
+          cachedHtml = torrentInnerHtml.value
+
+          try {
+            const success = await fetchAndUpdate(url, buildParams(form, submitter))
+            if (success) {
+              await nextTick()
+              bindInfoPageEvents()
+            } else {
+              cachedHtml = ''
+            }
+          } catch (error) {
+            if (error instanceof Error) {
+              logger.error('failed to fetch torrent info.', error)
+            }
+            cachedHtml = ''
+          }
+        })
+      })
+    }
+
+    function bindInfoPageEvents() {
+      if (!popup.value) return
+
+      // 通用處理所有 form submit（Back to Index、Modify、Cancel 等）
+      const forms = popup.value.querySelectorAll<HTMLFormElement>('form:not(#expungeform)')
+      forms.forEach(form => {
+        form.addEventListener('submit', async event => {
+          event.preventDefault()
+          const submitter = (event as SubmitEvent).submitter
+
+          // Back to Index → 還原種子列表
+          if (submitter instanceof HTMLInputElement && submitter.name === 'list') {
+            const html = cachedHtml
+            cachedHtml = ''
+            torrentInnerHtml.value = html
+            await nextTick()
+            onContentChanged()
+            bindListFormEvents()
+            return
+          }
+
+          // 其他 submit（Modify、Cancel 等）→ fetch 並顯示回應
+          const url = form.getAttribute('action')
+          if (!url) return
+
+          const success = await fetchAndUpdate(url, buildParams(form, submitter))
+          if (success) {
+            await nextTick()
+            bindInfoPageEvents()
+          }
+        })
+      })
+
+      // Delete / Expunge（原站用 onclick + form.submit() 繞過 submit event）
+      const expungeLink = popup.value.querySelector<HTMLElement>('[onclick*="expungeform"]')
+      if (expungeLink) {
+        const isDelete = expungeLink.textContent?.includes('Delete')
+        const message = isDelete
+          ? 'Are you sure you wish to delete this torrent? This action cannot be undone.'
+          : 'Are you sure you wish to expunge this torrent? This action cannot be undone.'
+
+        expungeLink.removeAttribute('onclick')
+        expungeLink.addEventListener('click', async event => {
+          event.preventDefault()
+          if (!confirm(message)) return
+
+          const form = popup.value?.querySelector<HTMLFormElement>('#expungeform')
+          const url = form?.getAttribute('action')
+          if (!form || !url) return
+
+          const success = await fetchAndUpdate(url, buildParams(form))
+          if (success) {
+            await nextTick()
+            bindInfoPageEvents()
+          }
+        })
+      }
+    }
+  }
+
   return {
     downloadTorrent,
     extractMagnetLink,
     addMagnetCopyButtons,
+    setTorrentPopupEvents,
   }
 }


### PR DESCRIPTION
related #78

完善 torrent popup 的功能，使所有操作皆可在 modal 內完成，不再需要開啟新頁面。

  - 攔截 torrent popup 內的 form submit，改為在 modal 內導航
  - 支援查看 Information、Modify、Cancel、Delete/Expunge、Back to Index等操作
  - 上傳種子（`multipart/form-data`）在新分頁開啟，跨域問題
  
  
<img width="1519" height="578" alt="PixPin_2026-02-17_22-12-04" src="https://github.com/user-attachments/assets/779a5fd2-5a7f-49c4-b241-96cb941a7f9e" />

<img width="1281" height="1252" alt="PixPin_2026-02-18_11-10-29" src="https://github.com/user-attachments/assets/a2a88826-0f20-4142-9a63-a4ffa90d36bc" />
