### PR TITLE
fix(galleries): restore overflow-anchor: none on .searchnav

### DIFF
--- a/src/components/Galleries/GalleriesEnhancer.vue
+++ b/src/components/Galleries/GalleriesEnhancer.vue
@@ -185,6 +185,10 @@ if (highlightSwitch.value) {
 <style lang="scss">
 @use "@/styles/animations/spin.scss";
 
+.searchnav {
+  overflow-anchor: none;
+}
+
 .itg.gld.is-fetching::after {
   grid-column: 1 / -1;
   display: flex;


### PR DESCRIPTION
fix #92 