### PR TITLE
Add "hide gallery" button

### DIFF
--- a/src/components/Galleries/GalleriesEnhancer.vue
+++ b/src/components/Galleries/GalleriesEnhancer.vue
@@ -11,6 +11,7 @@ import { scrollByRowSwitch, infiniteScrollSwitch, archiveButtonSwitch, highlight
 import { getArchiveLink } from '@/utils/e-hentai-api'
 import { useArchive } from '@/composables/useArchive'
 import { highlightDownloadedGalleries, watchDownloadedGalleries } from '@/utils/highlight-galleries'
+import { HiddenGalleries } from '@/utils/hidden-galleries'
 
 if (scrollByRowSwitch.value) {
   setWheelStep({
@@ -63,9 +64,65 @@ function useInfiniteScroll() {
 }
 
 const { archiveInnerHtml, fetchArchive } = usePopups()
+const hiddenGalleries = new HiddenGalleries()
 
 const archivePopup = ref<HTMLElement>()
 const activeButton = ref<HTMLElement>()
+
+function setHideButtonState(button: HTMLElement, isHidden: boolean) {
+  button.classList.toggle('is-hidden', isHidden)
+  button.title = isHidden ? 'Unhide gallery' : 'Hide gallery'
+}
+
+function appendHideButtons() {
+  const galleries = getElements('.gl1t')
+
+  galleries?.forEach(gallery => {
+    const title = hiddenGalleries.getGalleryTitle(gallery)
+    if (title === null) {
+      return
+    }
+
+    const existing = getElement('.hide-button', gallery) as HTMLElement | null
+    if (existing) {
+      setHideButtonState(existing, hiddenGalleries.isGalleryHidden(title))
+      return
+    }
+
+    const button = document.createElement('span')
+    button.classList.add('hide-button')
+    const isHidden = hiddenGalleries.isGalleryHidden(title)
+    button.textContent = '🚫'
+    setHideButtonState(button, isHidden)
+    button.onclick = (e) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const currentlyHidden = hiddenGalleries.isGalleryHidden(title)
+      const nextHidden = !currentlyHidden
+      hiddenGalleries.setGalleryHidden(title, nextHidden)
+      setHideButtonState(button, nextHidden)
+    }
+
+    const archiveBtn = getElement('.archive-button', gallery)
+    const downloadDiv = getElement('.gldown', gallery)
+    if (archiveBtn) {
+      archiveBtn.after(button)
+    } else {
+      downloadDiv?.appendChild(button)
+    }
+  })
+}
+
+function syncGalleriesEnhancerFeatures() {
+  hiddenGalleries.removeHiddenGalleries()
+  appendHideButtons()
+  if (archiveButtonSwitch.value) {
+    appendArchiveButtons()
+  }
+  if (highlightSwitch.value) {
+    highlightDownloadedGalleries()
+  }
+}
 
 async function appendArchiveButtons() {
   const galleries = getElements('.gl1t')
@@ -123,18 +180,19 @@ const archivePopupPosition = computed(() => {
   }
 })
 
-if (archiveButtonSwitch.value) {
-  appendArchiveButtons()
-}
+syncGalleriesEnhancerFeatures()
 
 const galleryContainer = getElement('.itg.gld')
 if (galleryContainer) {
   const observer = new MutationObserver(() => {
-    if (archiveButtonSwitch.value) appendArchiveButtons()
-    if (highlightSwitch.value) highlightDownloadedGalleries()
+    syncGalleriesEnhancerFeatures()
   })
   observer.observe(galleryContainer, { childList: true })
 }
+
+hiddenGalleries.watch(() => {
+  syncGalleriesEnhancerFeatures()
+})
 
 const modalOptions = ref({
   teleportTo: '.enhancer-container',
@@ -163,7 +221,6 @@ function setArchiveEvent() {
 }
 
 if (highlightSwitch.value) {
-  highlightDownloadedGalleries()
   watchDownloadedGalleries()
 }
 </script>
@@ -212,13 +269,33 @@ if (highlightSwitch.value) {
   align-items: center;
   flex-shrink: 0;
   position: relative;
-  top: -6px;
-  margin-left: 4px;
-  width: 24px;
-  height: 24px;
+  width: 14px;
+  height: 14px;
   border-radius: 9999px;
   background-color: #5fa9cf;
   box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 5px;
   cursor: pointer;
+}
+
+.hide-button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+  position: relative;
+  height: 12px;
+  font-size: 14px;
+  cursor: pointer;
+  opacity: 0.25;
+  transition: opacity 0.15s ease-in-out;
+  user-select: none;
+
+  &:hover {
+    opacity: 0.6;
+  }
+
+  &.is-hidden {
+    opacity: 1;
+  }
 }
 </style>

--- a/src/components/Galleries/GalleriesEnhancer.vue
+++ b/src/components/Galleries/GalleriesEnhancer.vue
@@ -11,7 +11,7 @@ import { scrollByRowSwitch, infiniteScrollSwitch, archiveButtonSwitch, highlight
 import { getArchiveLink } from '@/utils/e-hentai-api'
 import { useArchive } from '@/composables/useArchive'
 import { highlightDownloadedGalleries, watchDownloadedGalleries } from '@/utils/highlight-galleries'
-import { HiddenGalleries } from '@/utils/hidden-galleries'
+import { getGalleryTitle, isGalleryHidden, setGalleryHidden, removeHiddenGalleries, watchHiddenGalleries } from '@/utils/hidden-galleries'
 
 if (scrollByRowSwitch.value) {
   setWheelStep({
@@ -64,7 +64,6 @@ function useInfiniteScroll() {
 }
 
 const { archiveInnerHtml, fetchArchive } = usePopups()
-const hiddenGalleries = new HiddenGalleries()
 
 const archivePopup = ref<HTMLElement>()
 const activeButton = ref<HTMLElement>()
@@ -78,28 +77,26 @@ function appendHideButtons() {
   const galleries = getElements('.gl1t')
 
   galleries?.forEach(gallery => {
-    const title = hiddenGalleries.getGalleryTitle(gallery)
+    const title = getGalleryTitle(gallery)
     if (title === null) {
       return
     }
 
-    const existing = getElement('.hide-button', gallery) as HTMLElement | null
+    const existing = getElement('.hide-button', gallery)
     if (existing) {
-      setHideButtonState(existing, hiddenGalleries.isGalleryHidden(title))
+      setHideButtonState(existing, isGalleryHidden(title))
       return
     }
 
     const button = document.createElement('span')
     button.classList.add('hide-button')
-    const isHidden = hiddenGalleries.isGalleryHidden(title)
     button.textContent = '🚫'
-    setHideButtonState(button, isHidden)
+    setHideButtonState(button, isGalleryHidden(title))
     button.onclick = (e) => {
       e.preventDefault()
       e.stopPropagation()
-      const currentlyHidden = hiddenGalleries.isGalleryHidden(title)
-      const nextHidden = !currentlyHidden
-      hiddenGalleries.setGalleryHidden(title, nextHidden)
+      const nextHidden = !isGalleryHidden(title)
+      setGalleryHidden(title, nextHidden)
       setHideButtonState(button, nextHidden)
     }
 
@@ -114,7 +111,7 @@ function appendHideButtons() {
 }
 
 function syncGalleriesEnhancerFeatures() {
-  hiddenGalleries.removeHiddenGalleries()
+  removeHiddenGalleries()
   appendHideButtons()
   if (archiveButtonSwitch.value) {
     appendArchiveButtons()
@@ -190,7 +187,7 @@ if (galleryContainer) {
   observer.observe(galleryContainer, { childList: true })
 }
 
-hiddenGalleries.watch(() => {
+watchHiddenGalleries(() => {
   syncGalleriesEnhancerFeatures()
 })
 

--- a/src/components/SettingsPanel/SettingsPanel.vue
+++ b/src/components/SettingsPanel/SettingsPanel.vue
@@ -19,6 +19,7 @@ import {
   changePageByWheelAnyWhereSwitch,
   showJapaneseTitle,
   highlightSwitch,
+  showHiddenGalleriesSwitch,
   magnifierSwitch,
   magnifierActivationButton,
   magnifierToggleMode,
@@ -326,6 +327,16 @@ function reload() {
           <h3 class="settings__name">
             Insert archiver buttons to galleries.
           </h3>
+        </div>
+
+        <div class="settings">
+          <ToggleSwitch v-model="showHiddenGalleriesSwitch.value" />
+          <h3 class="settings__name">
+            Show hidden galleries
+          </h3>
+          <div class="settings__intro">
+            When enabled, galleries you have hidden via the 🚫 button stay visible (with the icon shown opaque) so you can un-hide them.
+          </div>
         </div>
       </section>
     </div>

--- a/src/utils/gm-variables.ts
+++ b/src/utils/gm-variables.ts
@@ -6,6 +6,7 @@ export const enum GMKey {
   ScrollByRow = 'ScrollByRow',
   ArchiveButton = 'archiveButton',
   Highlight = 'Highlight',
+  ShowHiddenGalleries = 'ShowHiddenGalleries',
 
   BetterPopup = 'BetterPopup',
   QuickArchiveDownloadMethod = 'QuickDownloadMethod',
@@ -70,6 +71,7 @@ class GMVariable<T extends boolean | ArchiveDownloadMethod | MouseButton | numbe
 export const infiniteScrollSwitch = reactive(new GMVariable<boolean>(GMKey.InfiniteScroll, true))
 export const archiveButtonSwitch = reactive(new GMVariable<boolean>(GMKey.ArchiveButton, true))
 export const highlightSwitch = reactive(new GMVariable<boolean>(GMKey.Highlight, true))
+export const showHiddenGalleriesSwitch = reactive(new GMVariable<boolean>(GMKey.ShowHiddenGalleries, false))
 
 // Gallery enhancer
 export const scrollByRowSwitch = reactive(new GMVariable<boolean>(GMKey.ScrollByRow, true))
@@ -102,6 +104,7 @@ export async function initializeMonkeySwitches() {
     infiniteScrollSwitch.initialize(),
     archiveButtonSwitch.initialize(),
     highlightSwitch.initialize(),
+    showHiddenGalleriesSwitch.initialize(),
 
     scrollByRowSwitch.initialize(),
     betterPopupSwitch.initialize(),

--- a/src/utils/hidden-galleries.ts
+++ b/src/utils/hidden-galleries.ts
@@ -7,58 +7,49 @@ import {
 import { getElements } from '@/utils/commons'
 import { showHiddenGalleriesSwitch } from '@/utils/gm-variables'
 
-export const HIDDEN_GALLERIES_KEY = 'hidden-galleries-titles'
+const HIDDEN_GALLERIES_KEY = 'hidden-galleries-titles'
 
-export class HiddenGalleries {
-  private hiddenTitles = new Set<string>(gmGetValue(HIDDEN_GALLERIES_KEY, []))
+let hiddenTitles = new Set<string>(gmGetValue(HIDDEN_GALLERIES_KEY, []))
 
-  getGalleryTitle(gallery: HTMLElement): string | null {
-    try {
-      const title = gallery.querySelector('.gl4t.glname')?.textContent?.trim()
-      if (!title) {
-        return null
-      }
-      return title
-    } catch {
-      return null
-    }
+export function getGalleryTitle(gallery: HTMLElement): string | null {
+  const title = gallery.querySelector('.gl4t.glname')?.textContent?.trim()
+  return title || null
+}
+
+export function isGalleryHidden(title: string): boolean {
+  return hiddenTitles.has(title)
+}
+
+export function setGalleryHidden(title: string, hidden: boolean): void {
+  if (hidden) {
+    hiddenTitles.add(title)
+  } else {
+    hiddenTitles.delete(title)
+  }
+  gmSetValue(HIDDEN_GALLERIES_KEY, [...hiddenTitles])
+}
+
+export function removeHiddenGalleries(): void {
+  if (showHiddenGalleriesSwitch.value) {
+    return
   }
 
-  isGalleryHidden(title: string): boolean {
-    return this.hiddenTitles.has(title)
+  const galleries = getElements('.gl1t')
+  if (!galleries) {
+    return
   }
 
-  setGalleryHidden(title: string, hidden: boolean): void {
-    if (hidden) {
-      this.hiddenTitles.add(title)
-    } else {
-      this.hiddenTitles.delete(title)
-    }
-    gmSetValue(HIDDEN_GALLERIES_KEY, [...this.hiddenTitles])
-  }
-
-  removeHiddenGalleries(): void {
-    if (showHiddenGalleriesSwitch.value) {
-      return
-    }
-
-    const galleries = getElements('.gl1t')
-    if (!galleries) {
-      return
-    }
-
-    for (const gallery of [...galleries]) {
-      const title = this.getGalleryTitle(gallery)
-      if (title !== null && this.hiddenTitles.has(title)) {
-        gallery.remove()
-      }
+  for (const gallery of [...galleries]) {
+    const title = getGalleryTitle(gallery)
+    if (title !== null && hiddenTitles.has(title)) {
+      gallery.remove()
     }
   }
+}
 
-  watch(callback: () => void): void {
-    gmAddValueChangeListener(HIDDEN_GALLERIES_KEY, (_, __, nextValue) => {
-      this.hiddenTitles = new Set<string>(nextValue as string[])
-      callback()
-    })
-  }
+export function watchHiddenGalleries(callback: () => void): void {
+  gmAddValueChangeListener(HIDDEN_GALLERIES_KEY, (_, __, nextValue) => {
+    hiddenTitles = new Set<string>(nextValue as string[])
+    callback()
+  })
 }

--- a/src/utils/hidden-galleries.ts
+++ b/src/utils/hidden-galleries.ts
@@ -1,0 +1,64 @@
+import {
+  GM_getValue as gmGetValue,
+  GM_setValue as gmSetValue,
+  GM_addValueChangeListener as gmAddValueChangeListener,
+} from 'vite-plugin-monkey/dist/client'
+
+import { getElements } from '@/utils/commons'
+import { showHiddenGalleriesSwitch } from '@/utils/gm-variables'
+
+export const HIDDEN_GALLERIES_KEY = 'hidden-galleries-titles'
+
+export class HiddenGalleries {
+  private hiddenTitles = new Set<string>(gmGetValue(HIDDEN_GALLERIES_KEY, []))
+
+  getGalleryTitle(gallery: HTMLElement): string | null {
+    try {
+      const title = gallery.querySelector('.gl4t.glname')?.textContent?.trim()
+      if (!title) {
+        return null
+      }
+      return title
+    } catch {
+      return null
+    }
+  }
+
+  isGalleryHidden(title: string): boolean {
+    return this.hiddenTitles.has(title)
+  }
+
+  setGalleryHidden(title: string, hidden: boolean): void {
+    if (hidden) {
+      this.hiddenTitles.add(title)
+    } else {
+      this.hiddenTitles.delete(title)
+    }
+    gmSetValue(HIDDEN_GALLERIES_KEY, [...this.hiddenTitles])
+  }
+
+  removeHiddenGalleries(): void {
+    if (showHiddenGalleriesSwitch.value) {
+      return
+    }
+
+    const galleries = getElements('.gl1t')
+    if (!galleries) {
+      return
+    }
+
+    for (const gallery of [...galleries]) {
+      const title = this.getGalleryTitle(gallery)
+      if (title !== null && this.hiddenTitles.has(title)) {
+        gallery.remove()
+      }
+    }
+  }
+
+  watch(callback: () => void): void {
+    gmAddValueChangeListener(HIDDEN_GALLERIES_KEY, (_, __, nextValue) => {
+      this.hiddenTitles = new Set<string>(nextValue as string[])
+      callback()
+    })
+  }
+}


### PR DESCRIPTION
Added a "hide gallery" button to galleries on the main galleries page.

<img width="397" height="579" alt="2026-05-11 01_21_48-NVIDIA GeForce Overlay DT" src="https://github.com/user-attachments/assets/13647dbf-c08c-4463-b735-13dfdb6f2593" />

Hidden galleries are remembered across page refreshes. Uses the title rather than the URL because the URL changes when galleries are updated.

Also adds a "Show Hidden Galleries" option to the settings, to allow unhiding galleries.