### PR TITLE
fix(archive): look up H@H links by resolution instead of column position

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,12 @@ Getting an Archive by queueing it on a Hentai@Home client instead of
 downloading it in the browser.
 _Avoid_: Hath download, client download
 
+**H@H Resolution**:
+The size an H@H Download is rendered at. The site decides which ones exist
+and which of those a given Gallery offers, so a resolution the user picked
+may be unavailable on the Gallery in front of them.
+_Avoid_: Quality, size, xres
+
 **Archive Session**:
 The download authorisation the archiver creates when a user pays to unlock an
 Archive. While it is active the same Archive can be downloaded again without

--- a/src/components/SettingsPanel/SettingsPanel.vue
+++ b/src/components/SettingsPanel/SettingsPanel.vue
@@ -101,22 +101,35 @@ function reload() {
               Action when clicking "Archive Download":
             </span>
             <select v-model="quickArchiveDownloadMethod.value" class="settings__select">
-              <option class="settings__option">
-                {{ ArchiveDownloadMethod.Manual }}
+              <option class="settings__option" :value="ArchiveDownloadMethod.Manual">
+                Manual
               </option>
-              <option class="settings__option">
-                {{ ArchiveDownloadMethod.HaH_Original }}
+              <option class="settings__option" :value="ArchiveDownloadMethod.HaH_Original">
+                download Original Resolution with H@H
               </option>
-              <option class="settings__option">
-                {{ ArchiveDownloadMethod.HaH_2400 }}
+              <option class="settings__option" :value="ArchiveDownloadMethod.HaH_800">
+                download 800x Resolution with H@H
               </option>
-              <option class="settings__option">
-                {{ ArchiveDownloadMethod.Direct_Origin }}
+              <option class="settings__option" :value="ArchiveDownloadMethod.HaH_1280">
+                download 1280x Resolution with H@H
               </option>
-              <option class="settings__option">
-                {{ ArchiveDownloadMethod.Direct_Resample }}
+              <option class="settings__option" :value="ArchiveDownloadMethod.HaH_1920">
+                download 1920x Resolution with H@H
+              </option>
+              <option class="settings__option" :value="ArchiveDownloadMethod.HaH_2560">
+                download 2560x Resolution with H@H
+              </option>
+              <option class="settings__option" :value="ArchiveDownloadMethod.Direct_Origin">
+                download Original Resolution directly
+              </option>
+              <option class="settings__option" :value="ArchiveDownloadMethod.Direct_Resample">
+                download Resample Resolution directly
               </option>
             </select>
+            <p>
+              *Note: Not every gallery offers every H@H resolution. When the one you picked isn't
+              available, the pop-up opens instead.
+            </p>
             <p>
               *Note: If you have changed the Archiver Settings, you must revert it to "Manual Select, Manual
               Start (Default)" on the settings page:

--- a/src/composables/useArchive.ts
+++ b/src/composables/useArchive.ts
@@ -20,6 +20,36 @@ const DOWNLOAD_LABELS: Record<ArchiveDownloadType, string> = {
 
 const DOWNLOAD_ACCEPTED_TEXT = 'Locating archive server and preparing file for download...'
 
+const HAH_ORIGINAL_RESOLUTION = 'org'
+
+/**
+ * quick download 的設定值對應的 H@H 解析度，值就是 archiver 的 `hathdl_xres`
+ *
+ * 這份清單只決定「設定面板上提供哪些選項」。某一本 gallery 實際提供哪些解析度，
+ * 要看 archiver 頁面上有沒有對應的連結 —— 不提供的那格會變灰而且連 `<a>` 都沒有
+ */
+const HAH_RESOLUTIONS: Partial<Record<ArchiveDownloadMethod, string>> = {
+  [ArchiveDownloadMethod.HaH_Original]: HAH_ORIGINAL_RESOLUTION,
+  [ArchiveDownloadMethod.HaH_800]: '800',
+  [ArchiveDownloadMethod.HaH_1280]: '1280',
+  [ArchiveDownloadMethod.HaH_1920]: '1920',
+  [ArchiveDownloadMethod.HaH_2560]: '2560',
+}
+
+/**
+ * 綁定事件時會把解析度記到這個屬性上
+ *
+ * 因為綁定的同時就把 `onclick` 移除了，之後想知道某個連結是哪個解析度只能靠它
+ */
+const HAH_RESOLUTION_ATTRIBUTE = 'data-hathdl-xres'
+
+/**
+ * 顯示給使用者看的解析度名稱，與 archiver 表格上的欄位標題一致
+ */
+function getResolutionLabel(resolution: string) {
+  return resolution === HAH_ORIGINAL_RESOLUTION ? 'Original' : `${resolution}x`
+}
+
 const INLINE_CANCEL_CLASS = 'enhancer-archive-cancel'
 
 /**
@@ -160,9 +190,9 @@ export function useArchive() {
     }
 
     for (const link of hentaiAtHomeLinks) {
-      const ORIGINAL_SIZE = 'org'
-      const resolution = link.getAttribute('onclick')?.split('\'')?.[1] || ORIGINAL_SIZE
+      const resolution = link.getAttribute('onclick')?.split('\'')?.[1] || HAH_ORIGINAL_RESOLUTION
       link.removeAttribute('onclick')
+      link.setAttribute(HAH_RESOLUTION_ATTRIBUTE, resolution)
 
       link.addEventListener('click', async event => {
         event.preventDefault()
@@ -392,42 +422,53 @@ export function useArchive() {
     })
   }
 
+  /**
+   * 點擊 popup 內對應解析度的 H@H 連結
+   *
+   * 不用位置選取。站方改過解析度階梯，而且不提供的解析度那格沒有 `<a>`，
+   * 所以「第幾格」和「哪個解析度」之間沒有固定關係
+   */
+  function startHentaiAtHomeDownload(popup: Ref<HTMLElement | undefined>, resolution: string) {
+    const logger = new Logger('Archive Event')
+
+    const link = getElement(`[${HAH_RESOLUTION_ATTRIBUTE}="${resolution}"]`, popup.value)
+    if (link) {
+      link.click()
+      return true
+    }
+
+    // 找得到其他解析度，就表示事件綁好了、只是這本 gallery 不提供這一階
+    if (getElements(`[${HAH_RESOLUTION_ATTRIBUTE}]`, popup.value)?.length) {
+      toast.warning(`This gallery doesn't offer H@H ${getResolutionLabel(resolution)}.\n Open popup`)
+      return false
+    }
+
+    logger.error('hentai@Home links not found.')
+    toast.error('Failed to find the H@H links.\n Open popup')
+    return false
+  }
+
   // TODO: 直接 send request 而非操作 DOM
   function quickDownload(popup: Ref<HTMLElement | undefined>) {
-    function getHaHDownloadLinkElement(downloadMethod: ArchiveDownloadMethod.HaH_Original | ArchiveDownloadMethod.HaH_2400) {
-      const indexMap = {
-        [ArchiveDownloadMethod.HaH_Original]: 6,
-        [ArchiveDownloadMethod.HaH_2400]: 5,
-      }
-      const index = indexMap[downloadMethod]
+    const logger = new Logger('Archive Event')
 
-      return getElement(`td:nth-child(${index}) > p > a`, popup.value)
+    const resolution = HAH_RESOLUTIONS[quickArchiveDownloadMethod.value]
+    if (resolution) {
+      return startHentaiAtHomeDownload(popup, resolution)
     }
 
-    switch (quickArchiveDownloadMethod.value) {
-      case ArchiveDownloadMethod.HaH_Original:
-      case ArchiveDownloadMethod.HaH_2400: {
-        const downloadLinkElement = getHaHDownloadLinkElement(quickArchiveDownloadMethod.value)
-
-        if (downloadLinkElement) {
-          downloadLinkElement.click()
-        } else {
-          toast.warning(`Failed ${quickArchiveDownloadMethod.value}. The link might not exists.\n Open popup`)
-          return false
-        }
-
-        break
-      }
-
-      case ArchiveDownloadMethod.Direct_Origin:
-        (getElement('input[value="Download Original Archive"]', popup.value) as HTMLElement).click()
-        break
-
-      case ArchiveDownloadMethod.Direct_Resample:
-        (getElement('input[value="Download Resample Archive"]', popup.value) as HTMLElement).click()
-        break
+    const dltype = getArchiveDownloadType(quickArchiveDownloadMethod.value)
+    if (!dltype) {
+      return true
     }
 
+    const downloadButton = getElement(`input[value="${DOWNLOAD_LABELS[dltype]}"]`, popup.value)
+    if (!downloadButton) {
+      logger.error(`download button for "${dltype}" not found.`)
+      return false
+    }
+
+    downloadButton.click()
     return true
   }
 

--- a/src/utils/gm-variables.ts
+++ b/src/utils/gm-variables.ts
@@ -60,10 +60,15 @@ export const enum MouseButton {
 class GMVariable<T extends boolean | ArchiveDownloadMethod | ArchiveSessionAction | MouseButton | number> {
   private _key: string
   private _value: T
+  private _legacyValues: Record<string, T>
 
-  constructor(key: string, defaultValue: T) {
+  /**
+   * @param legacyValues 舊版存進去、現在已經不合法的值，對應到現行的值
+   */
+  constructor(key: string, defaultValue: T, legacyValues: Record<string, T> = {}) {
     this._key = key
     this._value = defaultValue
+    this._legacyValues = legacyValues
   }
 
   get value(): T {
@@ -76,7 +81,16 @@ class GMVariable<T extends boolean | ArchiveDownloadMethod | ArchiveSessionActio
   }
 
   async initialize() {
-    this._value = await GM.getValue(this._key, this._value)
+    const stored = await GM.getValue(this._key, this._value)
+
+    const migrated = this._legacyValues[String(stored)]
+    if (migrated === undefined) {
+      this._value = stored
+      return
+    }
+
+    // 用 setter 寫回新值，所以遷移只會發生一次
+    this.value = migrated
   }
 }
 

--- a/src/utils/gm-variables.ts
+++ b/src/utils/gm-variables.ts
@@ -31,12 +31,35 @@ export const enum GMKey {
   ShowJapaneseTitle = 'ShowJapaneseTitle',
 }
 
+/**
+ * 點擊 Archive Download 時要用哪種方式下載
+ *
+ * 值刻意使用與顯示文字無關的短 key，這樣之後改文案不會動到已儲存的設定
+ */
 export const enum ArchiveDownloadMethod {
   Manual = 'Manual',
-  HaH_Original = 'download Original Resolution with H@H',
-  HaH_2400 = 'download 2400x Resolution with H@H',
-  Direct_Origin = 'download Original Resolution directly',
-  Direct_Resample = 'download Resample Resolution directly',
+  HaH_Original = 'HaH_org',
+  HaH_800 = 'HaH_800',
+  HaH_1280 = 'HaH_1280',
+  HaH_1920 = 'HaH_1920',
+  HaH_2560 = 'HaH_2560',
+  Direct_Origin = 'Direct_org',
+  Direct_Resample = 'Direct_res',
+}
+
+/**
+ * 舊版直接把顯示文字存進 GM storage，所以升級時要映射成新的短 key
+ *
+ * `Manual` 的值沒變，不需要遷移。
+ *
+ * 站方已經沒有 2400x 這一階了，而舊版的位置選取實際上抓到的是 2560x，
+ * 所以映射到 2560x 才不會改變這些使用者原本拿到的檔案。
+ */
+const LEGACY_ARCHIVE_DOWNLOAD_METHODS: Record<string, ArchiveDownloadMethod> = {
+  'download Original Resolution with H@H': ArchiveDownloadMethod.HaH_Original,
+  'download 2400x Resolution with H@H': ArchiveDownloadMethod.HaH_2560,
+  'download Original Resolution directly': ArchiveDownloadMethod.Direct_Origin,
+  'download Resample Resolution directly': ArchiveDownloadMethod.Direct_Resample,
 }
 
 /**
@@ -103,7 +126,7 @@ export const showHiddenGalleriesSwitch = reactive(new GMVariable<boolean>(GMKey.
 // Gallery enhancer
 export const scrollByRowSwitch = reactive(new GMVariable<boolean>(GMKey.ScrollByRow, true))
 export const betterPopupSwitch = reactive(new GMVariable<boolean>(GMKey.BetterPopup, true))
-export const quickArchiveDownloadMethod = reactive(new GMVariable<ArchiveDownloadMethod>(GMKey.QuickArchiveDownloadMethod, ArchiveDownloadMethod.Manual))
+export const quickArchiveDownloadMethod = reactive(new GMVariable<ArchiveDownloadMethod>(GMKey.QuickArchiveDownloadMethod, ArchiveDownloadMethod.Manual, LEGACY_ARCHIVE_DOWNLOAD_METHODS))
 export const archiveSessionAction = reactive(new GMVariable<ArchiveSessionAction>(GMKey.ArchiveSessionAction, ArchiveSessionAction.DownloadDirectly))
 export const quickTorrentDownloadSwitch = reactive(new GMVariable<boolean>(GMKey.QuickTorrentDownload, false))
 export const loadAllGalleryImagesSwitch = reactive(new GMVariable<boolean>(GMKey.LoadAllGalleryImages, true))


### PR DESCRIPTION
Closes #99

## What was wrong

`quickDownload` picked the H@H link by column position — `Original` → `td:nth-child(6)`, `2400x` → `td:nth-child(5)`.

The site has since reordered the table and changed the resolution ladder. It now offers exactly five columns with the original first:

| `td:nth-child()` | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|
| label | Original | 800x | 1280x | 1920x | 2560x |
| `hathdl_xres` | `org` | `800` | `1280` | `1920` | `2560` |

So `nth-child(6)` never matched — `Original` was completely unusable — while `nth-child(5)` silently downloaded **2560x** for everyone who picked 2400x. The second half is the dangerous one: no error, just the wrong file.

`2400x` no longer exists as a resolution at all, so the option's own name was stale.

## What this changes

**Look up links by resolution, not position.** `setHentaiAtHomeEvent` already parses `do_hathdl('<xres>')` correctly, and it strips the `onclick` while binding — so by the time `quickDownload` runs there is nothing left to parse. It now records the resolution on the link as `data-hathdl-xres`, and `quickDownload` looks it up by that. One place parses the resolution, and `refreshArchivePopup` re-binding after a cancelled archive session brings the attribute back with it.

**Report "not offered" separately from "lookup failed".** A gallery that doesn't offer a resolution renders that cell grey with `N/A` and no `<a>`, so both cases used to surface as the same `The link might not exists` warning — part of why this went unnoticed for so long. The distinction is now made by whether *any* `[data-hathdl-xres]` link exists in the popup: some but not this one → this gallery doesn't offer it (warning, opens the popup); none at all → the binding failed (error + console log).

**Offer the resolutions that actually exist**: Original / 800x / 1280x / 1920x / 2560x.

**Decouple the stored values from the option labels.** `ArchiveDownloadMethod`'s values *were* the option text, which is why the stale `2400x` name survived — renaming it would have discarded whatever the user had saved. The members now have stable short keys, the `<option>`s bind with `:value`, and `GMVariable` takes an optional map of legacy values that it migrates once and writes back.

`download 2400x Resolution with H@H` migrates to **2560x** — that is what those users were already receiving, so the migration doesn't change anyone's downloads.

## Also in here

- `quickDownload` used `(getElement(...) as HTMLElement).click()` for the two direct-download buttons, which threw if the button wasn't found. It now falls back to opening the popup, and reuses the existing `DOWNLOAD_LABELS` constant instead of repeating the English labels.
- `CONTEXT.md` gains **H@H Resolution**, since which resolutions exist is the site's call and a picked one may simply be unavailable.
